### PR TITLE
Bugfixes for OSX

### DIFF
--- a/onedrive-base
+++ b/onedrive-base
@@ -246,11 +246,10 @@ function onedrive_acquire_access_token() {
 # --------------------------------- #
 # $1=file
 function filesystem_get_filesize() {	
-	unamestr=`uname`
-	if [[ "$unamestr" == 'Linux' ]]; then
-  		du -b "$1" | cut -f1
-	elif [[ "$unamestr" == 'Darwin' ]]; then
-   		stat -f%z "$1"
+	if [[ $(uname) == 'Darwin' ]]; then
+  		stat -f%z "$1"
+	else
+   		du -b "$1" | cut -f1
 	fi	
 }
 

--- a/onedrive-base
+++ b/onedrive-base
@@ -246,7 +246,7 @@ function onedrive_acquire_access_token() {
 # --------------------------------- #
 # $1=file
 function filesystem_get_filesize() {	
-	if [[ $(uname) == 'Darwin' ]]; then
+	if [[ $(uname) == "Darwin" ]]; then
   		stat -f%z "$1"
 	else
    		du -b "$1" | cut -f1

--- a/onedrive-base
+++ b/onedrive-base
@@ -245,8 +245,13 @@ function onedrive_acquire_access_token() {
 # --- UPLOAD SESSION MANAGEMENT --- #
 # --------------------------------- #
 # $1=file
-function filesystem_get_filesize() {
-	du -b "$1" | cut -f1
+function filesystem_get_filesize() {	
+	unamestr=`uname`
+	if [[ "$unamestr" == 'Linux' ]]; then
+  		du -b "$1" | cut -f1
+	elif [[ "$unamestr" == 'Darwin' ]]; then
+   		stat -f%z "$1"
+	fi	
 }
 
 # $1=folder id


### PR DESCRIPTION
The “du” in OS X  does not have “-b” option, so we need to use “stat”
instead. See here for more details:
http://stackoverflow.com/questions/18689592/how-to-get-image-size-in-bytes-in-osx-terminal-bash-for-apple-transporter-file