### PR TITLE
Use stat to determine filesize in bytes (replaces du on Linux systems)

### DIFF
--- a/onedriveb-base
+++ b/onedriveb-base
@@ -268,7 +268,7 @@ function filesystem_get_filesize() {
 	if [[ $(uname) == "Darwin" ]]; then
   		stat -f%z "$1"
 	else
-   		du -b "$1" | cut -f1
+   		stat -c%s "$1"
 	fi
 }
 


### PR DESCRIPTION
Synced with fkalis/bash-onedrive-upload master and replaced `du` with `stat` in `onedriveb-upload`